### PR TITLE
feat: Add support for the `isEventQlTrue` precondition

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ const writtenEvents = await client.writeEvents([
 
 *Note that according to the CloudEvents standard, event IDs must be of type string.*
 
+#### Using the `isEventQlTrue` precondition
+
+If you want to write events depending on an EventQL query, import the `isEventQlTrue` function and pass it as an array of preconditions in the second argument:
+
+```typescript
+import { isEventQlTrue } from 'eventsourcingdb';
+
+const writtenEvents = await client.writeEvents([
+  // events
+], [
+  isEventQlTrue('FROM e IN events WHERE e.type == \'io.eventsourcingdb.library.book-borrowed\' PROJECT INTO COUNT() < 10')
+]);
+```
+
+*Note that the query must return a single row with a single value, which is interpreted as a boolean.*
+
 ### Reading Events
 
 To read all events of a subject, call the `readEvents` function with the subject as the first argument and an options object as the second argument. Set the `recursive` option to `false`. This ensures that only events of the given subject are returned, not events of nested subjects.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ import { isEventQlTrue } from 'eventsourcingdb';
 const writtenEvents = await client.writeEvents([
   // events
 ], [
-  isEventQlTrue('FROM e IN events WHERE e.type == \'io.eventsourcingdb.library.book-borrowed\' PROJECT INTO COUNT() < 10')
+  isEventQlTrue(`FROM e IN events WHERE e.type == 'io.eventsourcingdb.library.book-borrowed' PROJECT INTO COUNT() < 10`)
 ]);
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,1 +1,1 @@
-FROM thenativeweb/eventsourcingdb:1.0.3
+FROM thenativeweb/eventsourcingdb:preview

--- a/src/Precondition.ts
+++ b/src/Precondition.ts
@@ -7,6 +7,10 @@ interface IsSubjectOnEventIdPrecondition {
 	eventId: string;
 }
 
+interface IsEventQlTruePrecondition {
+	query: string;
+}
+
 type Precondition =
 	| {
 			type: 'isSubjectPristine';
@@ -15,6 +19,10 @@ type Precondition =
 	| {
 			type: 'isSubjectOnEventId';
 			payload: IsSubjectOnEventIdPrecondition;
+	  }
+	| {
+			type: 'isEventQLTrue';
+			payload: IsEventQlTruePrecondition;
 	  };
 
 export type { Precondition };

--- a/src/Precondition.ts
+++ b/src/Precondition.ts
@@ -21,7 +21,7 @@ type Precondition =
 			payload: IsSubjectOnEventIdPrecondition;
 	  }
 	| {
-			type: 'isEventQLTrue';
+			type: 'isEventQlTrue';
 			payload: IsEventQlTruePrecondition;
 	  };
 

--- a/src/isEventQlTrue.ts
+++ b/src/isEventQlTrue.ts
@@ -1,0 +1,10 @@
+import type { Precondition } from './Precondition.js';
+
+const isEventQlTrue = (query: string): Precondition => {
+	return {
+		type: 'isEventQLTrue',
+		payload: { query },
+	};
+};
+
+export { isEventQlTrue };

--- a/src/isEventQlTrue.ts
+++ b/src/isEventQlTrue.ts
@@ -2,7 +2,7 @@ import type { Precondition } from './Precondition.js';
 
 const isEventQlTrue = (query: string): Precondition => {
 	return {
-		type: 'isEventQLTrue',
+		type: 'isEventQlTrue',
 		payload: { query },
 	};
 };

--- a/src/writeEvents.test.ts
+++ b/src/writeEvents.test.ts
@@ -145,7 +145,7 @@ suite('writeEvents', { timeout: 30_000 }, () => {
 		);
 	});
 
-	test('supports the isEventQLTrue precondition.', async (): Promise<void> => {
+	test('supports the isEventQlTrue precondition.', async (): Promise<void> => {
 		const client = container.getClient();
 
 		const firstEvent: EventCandidate = {

--- a/src/writeEvents.test.ts
+++ b/src/writeEvents.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, suite, test } from 'node:test';
 import { Container } from './Container.js';
 import type { EventCandidate } from './EventCandidate.js';
 import { getImageVersionFromDockerfile } from './getImageVersionFromDockerfile.js';
+import { isEventQlTrue } from './isEventQlTrue.js';
 import { isSubjectOnEventId } from './isSubjectOnEventId.js';
 import { isSubjectPristine } from './isSubjectPristine.js';
 
@@ -132,6 +133,47 @@ suite('writeEvents', { timeout: 30_000 }, () => {
 		await assert.rejects(
 			async () => {
 				await client.writeEvents([secondEvent], [isSubjectOnEventId('/test', '1')]);
+			},
+			error => {
+				assert.ok(error instanceof Error);
+				assert.equal(
+					error.message,
+					"Failed to write events, got HTTP status code '409', expected '200'.",
+				);
+				return true;
+			},
+		);
+	});
+
+	test('supports the isEventQLTrue precondition.', async (): Promise<void> => {
+		const client = container.getClient();
+
+		const firstEvent: EventCandidate = {
+			source: 'https://www.eventsourcingdb.io',
+			subject: '/test',
+			type: 'io.eventsourcingdb.test',
+			data: {
+				value: 23,
+			},
+		};
+
+		await client.writeEvents([firstEvent]);
+
+		const secondEvent: EventCandidate = {
+			source: 'https://www.eventsourcingdb.io',
+			subject: '/test',
+			type: 'io.eventsourcingdb.test',
+			data: {
+				value: 42,
+			},
+		};
+
+		await assert.rejects(
+			async () => {
+				await client.writeEvents(
+					[secondEvent],
+					[isEventQlTrue('FROM e IN events PROJECT INTO COUNT() == 0')],
+				);
 			},
 			error => {
 				assert.ok(error instanceof Error);


### PR DESCRIPTION
Adds support for the `isEventQlTrue` precondition to write depending on an EventQL query. Only available using the `preview` Docker image at this point in time.