### PR TITLE
fix: Ignore EventQL heartbeats

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -226,6 +226,9 @@ class Client {
 				}
 
 				for await (const line of readNdJsonStream(response.body, combinedSignal)) {
+					if (isStreamHeartbeat(line)) {
+						continue;
+					}
 					if (isStreamError(line)) {
 						throw new Error(`${line.payload.error}.`);
 					}


### PR DESCRIPTION
Ignores heartbeat intervals from long lasting EventQL queries