### PR TITLE
chore: migrate to TypeScript 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "get-port": "7.2.0",
         "tsup": "8.5.1",
         "tsx": "4.21.0",
-        "typescript": "5.9.3"
+        "typescript": "6.0.2"
       }
     },
     "node_modules/@balena/dockerignore": {
@@ -3342,9 +3342,9 @@
       "license": "Unlicense"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "get-port": "7.2.0",
     "tsup": "8.5.1",
     "tsx": "4.21.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.2"
   },
   "scripts": {
     "analyze": "npx tsc --noEmit && npx biome check --error-on-warnings .",

--- a/src/stream/isStreamCloudEvent.ts
+++ b/src/stream/isStreamCloudEvent.ts
@@ -1,8 +1,8 @@
-import { isRecord } from 'src/types/isRecord.js';
-import { isString } from 'src/types/isString.js';
-import { isStringOrNull } from 'src/types/isStringOrNull.js';
-import { isStringOrUndefined } from 'src/types/isStringOrUndefined.js';
 import { hasShapeOf } from '../types/hasShapeOf.js';
+import { isRecord } from '../types/isRecord.js';
+import { isString } from '../types/isString.js';
+import { isStringOrNull } from '../types/isStringOrNull.js';
+import { isStringOrUndefined } from '../types/isStringOrUndefined.js';
 import type { StreamCloudEvent } from './StreamCloudEvent.js';
 
 const isStreamCloudEvent = (line: unknown): line is StreamCloudEvent => {

--- a/src/stream/isStreamError.ts
+++ b/src/stream/isStreamError.ts
@@ -1,5 +1,5 @@
-import { isString } from 'src/types/isString.js';
 import { hasShapeOf } from '../types/hasShapeOf.js';
+import { isString } from '../types/isString.js';
 import type { StreamError } from './StreamError.js';
 
 const isStreamError = (line: unknown): line is StreamError => {

--- a/src/stream/isStreamEventType.ts
+++ b/src/stream/isStreamEventType.ts
@@ -1,6 +1,6 @@
-import { isBoolean } from 'src/types/isBoolean.js';
-import { isString } from 'src/types/isString.js';
 import { hasShapeOf } from '../types/hasShapeOf.js';
+import { isBoolean } from '../types/isBoolean.js';
+import { isString } from '../types/isString.js';
 import type { StreamEventType } from './StreamEventType.js';
 
 const isStreamEventType = (line: unknown): line is StreamEventType => {

--- a/src/stream/isStreamSubject.ts
+++ b/src/stream/isStreamSubject.ts
@@ -1,5 +1,5 @@
-import { isString } from 'src/types/isString.js';
 import { hasShapeOf } from '../types/hasShapeOf.js';
+import { isString } from '../types/isString.js';
 import type { StreamSubject } from './StreamSubject.js';
 
 const isStreamSubject = (line: unknown): line is StreamSubject => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
 	"compilerOptions": {
-		"baseUrl": ".",
+		"ignoreDeprecations": "6.0",
 		"declaration": true,
-		"esModuleInterop": true,
 		"lib": ["ES2023"],
-		"module": "CommonJS",
+		"module": "preserve",
+		"moduleResolution": "bundler",
 		"outDir": "dist",
 		"resolveJsonModule": true,
 		"strict": true,
-		"target": "ES2023"
+		"target": "ES2023",
+		"types": ["node"]
 	},
 	"include": ["./src/**/*.ts"],
 	"exclude": ["./dist"]


### PR DESCRIPTION
## Summary

- **Update TypeScript** from 5.9.3 to 6.0.2 (last JS-based release before the Go rewrite in TS 7.0)
- **Remove deprecated `baseUrl`** option and migrate absolute imports (`src/types/...`) to relative imports (`../types/...`) in 4 stream files
- **Remove `esModuleInterop: true`** — always enabled in TS 6.0, no longer configurable
- **Change `module`** from `CommonJS` to `preserve` — tsup handles the actual bundling
- **Add `moduleResolution: bundler`** — the implicit `node10` default is deprecated
- **Add `types: ["node"]`** — new default is `[]`, which would break Node.js global type resolution
- **Add `ignoreDeprecations: "6.0"`** — needed because tsup internally uses `baseUrl` for DTS generation (can be removed once tsup ships a TS 6.0-compatible update)

## Test plan

- [ ] `npm run analyze` passes (type-checking + biome linting)
- [ ] `npm run build` produces `dist/index.js`, `dist/index.mjs`, `dist/index.d.ts`
- [ ] `npm run test` passes (requires EventSourcingDB container)
- [ ] No new TypeScript deprecation warnings

https://claude.ai/code/session_0168r2kkTqkaA39YaV2XPVac